### PR TITLE
Wrong login don't take error

### DIFF
--- a/server/api/auth.py
+++ b/server/api/auth.py
@@ -18,4 +18,6 @@ def verify_password(username_or_token, password):
 
 @auth.error_handler
 def unauthorized_error():
-    return unauthorized('Please authenticate to access this token API')
+    res = unauthorized('Please authenticate to access this token API')
+    res.headers['WWW-Authenticate'] = 'x' + auth.authenticate_header()
+    return res

--- a/server/api/token.py
+++ b/server/api/token.py
@@ -16,7 +16,9 @@ def verify_password(username_or_token, password):
 
 @token_auth.error_handler
 def unauthorized_error():
-    return unauthorized('Please authenticate to access this API')
+    res = unauthorized('Please authenticate to access this token API')
+    res.headers['WWW-Authenticate'] = 'x' + token_auth.authenticate_header()
+    return res
 
 
 @token.route('/request-token')


### PR DESCRIPTION
---
name: Bug report
about: Create a report to help us improve

---

<!--
Please thoroughly read NVDA's wiki article on how to fill in this template, including how to provide the required files.
Issues may be closed if the required information is not present.
https://github.com/nvaccess/nvda/wiki/Github-issue-template-explanation-and-examples
-->

### Steps to reproduce:

1. Open Chrome
1. Browse to 127.0.0.1
1. Try login with wrong user and password (`aaa:aaa`)
1. Press Enter

### Actual behavior:

![image](https://user-images.githubusercontent.com/6695037/80309304-a3c4df80-87aa-11ea-879d-43d6ad3417fb.png)

Show a login `alert()`

### Expected behavior:

Show a wrong login and password message.

### System configuration
#### Version:

2.0.0

#### Windows/Linux version:

Ubuntu 18.04.4 LTS

#### Name and version of other software in use when reproducing the issue:

#### Other information about your system:

### Other questions
#### Does the issue still occur after restarting your computer?

Yes